### PR TITLE
Add notification on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@nodegui/nodegui": "^0.18.2",
+    "copy-webpack-plugin": "^5.1.1",
     "dateformat": "^3.0.3",
     "jp-wrap": "^0.2.2",
     "node-notifier": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "debug": "webpack && qode --inspect ./dist/index.js"
   },
   "dependencies": {
-    "@nodegui/nodegui": "^0.18.2",
+    "@nodegui/nodegui": "^0.19.0",
     "copy-webpack-plugin": "^5.1.1",
     "dateformat": "^3.0.3",
     "jp-wrap": "^0.2.2",

--- a/src/tools/desktop_notification/index.js
+++ b/src/tools/desktop_notification/index.js
@@ -1,5 +1,9 @@
 const notifier = require('node-notifier');
-
+const path = require('path');
+const winToast = new notifier.WindowsToaster({
+  withFallback: false,
+  customPath: path.resolve('./dist/snoreToast/snoretoast-x86.exe')
+});
 class DesktopNotification{
   constructor(){
   }
@@ -7,13 +11,23 @@ class DesktopNotification{
   show(title, message){
     if(!title) return;
     if(!this.is_enable) return;
-
     // 音とか追加するためにクラス作っとく
-
-    notifier.notify({
-      title: title,
-      message: message
-    });
+    if(process.platform == 'win32') {
+      winToast.notify({
+        appId: 'com.tencha',
+        message: message,
+        title: title,
+        sound: false,
+        wait: true
+      },function(err, response) {
+          console.log(err, response)
+        });
+    } else {
+      notifier.notify({
+        title: title,
+        message: message
+      });
+    }
   }
 
   set_is_enable(is_enable){

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
+const CopyPlugin = require('copy-webpack-plugin');
 
 module.exports = {
   mode: process.NODE_ENV || "development",
@@ -39,5 +40,10 @@ module.exports = {
   resolve: {
     extensions: [".tsx", ".ts", ".js", ".jsx"]
   },
-  plugins: [new CleanWebpackPlugin()]
+  plugins: [
+    new CleanWebpackPlugin(),
+    new CopyPlugin([
+      { from: './node_modules/node-notifier/vendor/snoreToast/snoretoast-x86.exe', to: './snoreToast/snoretoast-x86.exe' },
+      { from: './node_modules/node-notifier/vendor/snoreToast/snoretoast-x64.exe', to: './snoreToast/snoretoast-x64.exe' },
+    ])]
 };


### PR DESCRIPTION
Windowsで通知を出せるという力業

* webpackのプラグインで""node-notifierのWindowsで通知出してくれるソフト(`node-notifier/vendor/snoreToast/snoretoast-x{86|64}.exe`)""を無理矢理`dist/exe`内に突っ込ませる
* 上記理由よりビルドしないと出ない(逆に「デバッグ状態じゃないと出ない」にもできるが両方はムリ)
* アイコンがアレ
* トーストの名前がアレ

![image](https://user-images.githubusercontent.com/17561618/80488042-b997f780-8998-11ea-91b6-82d68d338ffc.png)
